### PR TITLE
fix: jx secret populate for local secrets

### DIFF
--- a/pkg/cmd/populate/populate.go
+++ b/pkg/cmd/populate/populate.go
@@ -192,7 +192,7 @@ func (o *Options) populateLoop(results []*secretfacade.SecretPair, waited map[st
 		newValueMap := map[string]bool{}
 		for i := range data {
 			d := &data[i]
-			key := d.Key
+			key := GetSecretKey(v1alpha1.BackendType(backendType), r.ExternalSecret.Name, d.Key)
 			property := d.Property
 			entryName := d.Name
 			keyProperties := m[key]


### PR DESCRIPTION
as we need to use the same key to modify all properties of a Secret in one go for tls secrets

Signed-off-by: James Strachan <james.strachan@gmail.com>