### PR TITLE
fix: change location where secrets are written to

### DIFF
--- a/pkg/extsecrets/helpers.go
+++ b/pkg/extsecrets/helpers.go
@@ -117,7 +117,7 @@ func CopySecretToNamespace(kubeClient kubernetes.Interface, ns string, fromSecre
 func DefaultHelmSecretFolder() string {
 	answer := os.Getenv("JX_HELM_SECRET_FOLDER")
 	if answer == "" {
-		answer, _ = filepath.Abs(filepath.Join("tmp", "secrets", "jx-helm"))
+		answer = filepath.Join(os.TempDir(), "secrets", "jx-helm")
 	}
 	return answer
 }


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

The previous code was returning `/workspace/source/tmp/secrets/jx-helm`.
Hence secrets were written to tmp folder in the cluster git repository.

Basically `filepath.Abs` returns `/workspace/source` when running inside the bootjob.