### PR TITLE
refactor: use T.TempDir to create temporary test directory

### DIFF
--- a/pkg/cmd/convert/convert_test.go
+++ b/pkg/cmd/convert/convert_test.go
@@ -28,8 +28,7 @@ func TestToExtSecrets(t *testing.T) {
 	fileNames, err := ioutil.ReadDir(sourceData)
 	assert.NoError(t, err)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	type testCase struct {
 		SourceFile   string
@@ -98,8 +97,7 @@ func TestToNamespaceSpecificExtSecrets(t *testing.T) {
 	fileNames, err := ioutil.ReadDir(sourceData)
 	assert.NoError(t, err)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	type testCase struct {
 		SourceFile   string
@@ -168,8 +166,7 @@ func TestToUnsecuredSecrets(t *testing.T) {
 	fileNames, err := ioutil.ReadDir(sourceData)
 	assert.NoError(t, err)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	type testCase struct {
 		SourceFile   string
@@ -238,8 +235,7 @@ func TestMultipleBackendTypes(t *testing.T) {
 	fileNames, err := ioutil.ReadDir(sourceData)
 	assert.NoError(t, err)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	type testCase struct {
 		SourceFile   string
@@ -307,8 +303,7 @@ func TestAlicloud(t *testing.T) {
 	fileNames, err := ioutil.ReadDir(sourceData)
 	assert.NoError(t, err)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	type testCase struct {
 		SourceFile   string
@@ -390,8 +385,7 @@ func TestAWSSecretsManager(t *testing.T) {
 	fileNames, err := ioutil.ReadDir(sourceData)
 	assert.NoError(t, err)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	type testCase struct {
 		SourceFile   string
@@ -472,8 +466,7 @@ func TestAWSParameterStore(t *testing.T) {
 	fileNames, err := ioutil.ReadDir(sourceData)
 	assert.NoError(t, err)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	type testCase struct {
 		SourceFile   string
@@ -555,8 +548,7 @@ func TestIBMSecretsManager(t *testing.T) {
 	fileNames, err := ioutil.ReadDir(sourceData)
 	assert.NoError(t, err)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	type testCase struct {
 		SourceFile   string
@@ -638,8 +630,7 @@ func TestAzureKeyVault(t *testing.T) {
 	fileNames, err := ioutil.ReadDir(sourceData)
 	assert.NoError(t, err)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	type testCase struct {
 		SourceFile   string
@@ -713,10 +704,9 @@ func TestConvertAndSchemaEnrich(t *testing.T) {
 	sourceData := filepath.Join("test_data", "schema")
 	require.DirExists(t, sourceData)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
-	err = files.CopyDir(sourceData, tmpDir, true)
+	err := files.CopyDir(sourceData, tmpDir, true)
 	require.NoError(t, err, "failed to copy %s to %s", sourceData, tmpDir)
 
 	_, eo := convert.NewCmdSecretConvert()
@@ -787,10 +777,9 @@ func TestConvertAndSchemaEnrichWithLocalSchemas(t *testing.T) {
 	sourceData := filepath.Join("test_data", "local-schema")
 	require.DirExists(t, sourceData)
 
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
-	err = files.CopyDir(sourceData, tmpDir, true)
+	err := files.CopyDir(sourceData, tmpDir, true)
 	require.NoError(t, err, "failed to copy %s to %s", sourceData, tmpDir)
 
 	_, eo := convert.NewCmdSecretConvert()

--- a/pkg/cmd/convert/edit/edit_test.go
+++ b/pkg/cmd/convert/edit/edit_test.go
@@ -2,7 +2,6 @@ package edit_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -61,9 +60,7 @@ func TestCmdSecretsMappingEdit(t *testing.T) {
 			},
 		},
 	}
-	tmpDir, err := ioutil.TempDir("", "jx-cmd-sec-")
-	require.NoError(t, err, "failed to create temp dir")
-	require.DirExists(t, tmpDir, "could not create temp dir for running tests")
+	tmpDir := t.TempDir()
 
 	for i, tt := range tests {
 		if tt.name == "" {
@@ -72,7 +69,7 @@ func TestCmdSecretsMappingEdit(t *testing.T) {
 		t.Logf("running test %s", tt.name)
 		dir := filepath.Join(tmpDir)
 
-		err = os.MkdirAll(dir, files.DefaultDirWritePermissions)
+		err := os.MkdirAll(dir, files.DefaultDirWritePermissions)
 		require.NoError(t, err, "failed to create dir %s", dir)
 
 		localSecretsFile := filepath.Join("test_data", tt.name)
@@ -81,7 +78,7 @@ func TestCmdSecretsMappingEdit(t *testing.T) {
 		cmd, _ := edit.NewCmdSecretMappingEdit()
 		tt.args = append(tt.args, "--dir", dir)
 
-		err := cmd.ParseFlags(tt.args)
+		err = cmd.ParseFlags(tt.args)
 		require.NoError(t, err, "failed to parse arguments %#v for test %s", tt.args, tt.name)
 
 		old := os.Args

--- a/pkg/cmd/replicate/replicate_test.go
+++ b/pkg/cmd/replicate/replicate_test.go
@@ -1,7 +1,6 @@
 package replicate_test
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -33,12 +32,11 @@ func TestReplicateBySelector(t *testing.T) {
 }
 
 func AssertReplicate(t *testing.T, callback func(o *replicate.Options)) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	sourceData := filepath.Join("test_data")
 
-	err = files.CopyDirOverwrite(sourceData, tmpDir)
+	err := files.CopyDirOverwrite(sourceData, tmpDir)
 	require.NoError(t, err, "failed to copy generated crds at %s to %s", sourceData, tmpDir)
 
 	_, o := replicate.NewCmdReplicate()


### PR DESCRIPTION
Follow up PR for https://github.com/jenkins-x-plugins/jx-gitops/pull/839#issuecomment-1079479757. This PR replaces `ioutil.TempDir` with `t.TempDir` in tests.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir