### PR TITLE
fix: always convert ASM secrets with property value set

### DIFF
--- a/pkg/cmd/convert/convert.go
+++ b/pkg/cmd/convert/convert.go
@@ -391,6 +391,9 @@ func (o *Options) convertData(node *yaml.RNode, path string, backendType v1alpha
 				case v1alpha1.BackendTypeLocal:
 					err = o.modifyLocal(rNode, field, secretName, path)
 
+				case v1alpha1.BackendTypeAWSSecretsManager:
+					err = o.modifyASM(rNode, field, secretName, path)
+
 				default:
 					err = o.modifyDefault(rNode, field, secretName, path, complexSecretType)
 				}
@@ -637,6 +640,10 @@ func (o *Options) modifyGSM(rNode *yaml.RNode, field, secretName, path string) e
 		return err
 	}
 	return nil
+}
+
+func (o *Options) modifyASM(rNode *yaml.RNode, field, secretName, path string) error {
+	return o.modifyDefault(rNode, field, secretName, path, true)
 }
 
 func (o *Options) moveMetadataToTemplate(node *yaml.RNode, path string) (bool, error) {

--- a/pkg/cmd/convert/test_data/awsSecretsManager/oauth2/expected.yaml
+++ b/pkg/cmd/convert/test_data/awsSecretsManager/oauth2/expected.yaml
@@ -15,6 +15,7 @@ spec:
   data:
     - name: azure.json
       key: azure-secret-name
+      property: azure.json
       versionStage: AWSPREVIOUS
   template:
     metadata:

--- a/pkg/cmd/convert/test_data/awsSecretsManager/oauth4/expected.yaml
+++ b/pkg/cmd/convert/test_data/awsSecretsManager/oauth4/expected.yaml
@@ -15,6 +15,7 @@ spec:
   data:
     - name: password
       key: unspecified-simple-type
+      property: password
       versionStage: AWSPREVIOUS
   template:
     metadata:


### PR DESCRIPTION
This is to fix the case when using ASM where `jx secret convert` converts secrets from Secret -> External Secret and always uses properties in the External Secret after [this change](https://github.com/jenkins-x-plugins/jx-secret/pull/346/files)