### PR TITLE
fix: improvements to edit

### DIFF
--- a/pkg/apis/external/v1/types.go
+++ b/pkg/apis/external/v1/types.go
@@ -107,6 +107,11 @@ type Data struct {
 	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 }
 
+// SecretLocation is the string representation of this unique property
+func (d Data) SecretLocation(backend string) string {
+	return fmt.Sprintf("%s/%s/%s/%s", backend, d.Key, d.Property, d.Version)
+}
+
 // Template the template data
 type Template struct {
 	// Type the type of the secret

--- a/pkg/cmd/replicate/replicate.go
+++ b/pkg/cmd/replicate/replicate.go
@@ -70,7 +70,7 @@ func NewCmdReplicate() (*cobra.Command, *Options) {
 	cmd.Flags().StringVarP(&o.File, "file", "f", "t", "the ExternalSecret to replicate")
 	cmd.Flags().StringVarP(&o.Selector, "selector", "s", "", "defines the label selector to find the ExternalSecret resources to replicate")
 	cmd.Flags().StringArrayVarP(&o.Name, "name", "n", nil, "specifies the names of the ExternalSecrets to replicate if not using a selector")
-	cmd.Flags().StringVarP(&o.From, "from", "", "", "one or more Namespaces to replicate the ExternalSecret to")
+	cmd.Flags().StringVarP(&o.From, "from", "", "", "one or more Namespaces to replicate the ExternalSecret from")
 	cmd.Flags().StringArrayVarP(&o.To, "to", "t", nil, "one or more Namespaces to replicate the ExternalSecret to")
 	cmd.Flags().StringVarP(&o.OutputDir, "output-dir", "o", "", "the output directory which defaults to 'config-root' in the directory")
 	return cmd, o

--- a/pkg/extsecrets/secretfacade/verify_filter.go
+++ b/pkg/extsecrets/secretfacade/verify_filter.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// VerifyAndFilter loads the secrets and verifies which are valid to aid the edit/populate operations
+// VerifyAndFilter loads the secrets and verifies which are valid to aid the populate operations
 // then filters out any duplicate entries which are using the same underlying secret mappings.
 //
 // e.g. if 2 secrets are populated to the same actual location then we can omit one of them since there's no need
@@ -104,10 +104,18 @@ func (a SchemaOrder) Less(i, j int) bool {
 			return true
 		}
 	}
-	if len(s1.ExternalSecret.Spec.Data) > len(s2.ExternalSecret.Spec.Data) {
+	es1 := s1.ExternalSecret
+	es2 := s2.ExternalSecret
+	if len(es1.Spec.Data) > len(es2.Spec.Data) {
 		return true
 	}
-	return s1.ExternalSecret.Name < s2.ExternalSecret.Name
+	if len(es1.Namespace) < len(es2.Namespace) {
+		return true
+	}
+	if es1.Name == es2.Name {
+		return es1.Namespace < es2.Namespace
+	}
+	return es1.Name < es2.Name
 }
 
 // SortSecretsInSchemaOrder sorts the secrets in schema order with the entry with a schema with the most properties being first


### PR DESCRIPTION
allow skipping property with ctrl+c
edit secrets in current names space (except for when going through all missing properties) adding correct removal of duplicate property locations for edit small usage correction